### PR TITLE
Rename 'whitelist' to 'ignore_list'

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ pf.profanity_count('test_string', strategies: [:partial_match, :leet])
 We also support an `ignore_list`, specified at object creation.
 
 ```ruby
-pf_with_ignore_list = ProfanityFilter.new(ignore_list: ['scunthorpe'])
+pf_with_ignore_list = ProfanityFilter.new(ignore_list: ['scunthorpe', /shii?take/i])
 pf_with_ignore_list.profane?('Scunthorpe United')
 # => false
-
+pf_with_ignore_list.profane?('Shitake mushrooms')
+# => false
 ```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ pf.profane?('test_string', strategies: [:partial_match, :leet])
 pf.profanity_count('test_string', strategies: [:partial_match, :leet])
 ```
 
-Also, we also supports `whitelist`, specified at object creation.
+We also support an `ignore_list`, specified at object creation.
 
 ```ruby
-pf_with_whitelist = ProfanityFilter.new(whitelist: ['asshole'])
-pf_with_whitelist.profane?('asshole')
+pf_with_ignore_list = ProfanityFilter.new(ignore_list: ['scunthorpe'])
+pf_with_ignore_list.profane?('Scunthorpe United')
 # => false
 
 ```

--- a/lib/profanity-filter.rb
+++ b/lib/profanity-filter.rb
@@ -22,11 +22,11 @@ class ProfanityFilter
 
   attr_reader :available_strategies
 
-  def initialize(web_purifier_api_key: nil, whitelist: [])
+  def initialize(web_purifier_api_key: nil, ignore_list: [])
     # If we are using Web Purifier
     @wp_client = web_purifier_api_key ? WebPurify::Client.new(web_purifier_api_key) : nil
-    @whitelist = whitelist
-    raise 'Whitelist should be an array' unless @whitelist.is_a?(Array)
+    @ignore_list = ignore_list
+    raise 'ignore_list should be an array' unless @ignore_list.is_a?(Array)
 
     exact_match_dictionary = load_exact_match_dictionary
     partial_match_dictionary = load_partial_match_dictionary
@@ -61,7 +61,10 @@ class ProfanityFilter
 
   def profane?(phrase, lang: nil, strategies: :basic)
     return false if phrase == ''
-    return false if @whitelist.include?(phrase)
+
+    @ignore_list.each do |ignore|
+      phrase = phrase.gsub(/#{ignore}/i, ' ')
+    end
 
     if use_webpurify?
       !!(pf_profane?(phrase, strategies: strategies) || wp_profane?(phrase, lang: lang))

--- a/lib/profanity-filter.rb
+++ b/lib/profanity-filter.rb
@@ -63,7 +63,8 @@ class ProfanityFilter
     return false if phrase == ''
 
     @ignore_list.each do |ignore|
-      phrase = phrase.gsub(/#{ignore}/i, ' ')
+      pattern = ignore.is_a?(Regexp) ? ignore : /#{ignore}/i
+      phrase = phrase.gsub(pattern, ' ')
     end
 
     if use_webpurify?

--- a/test/profanity_filter_test.rb
+++ b/test/profanity_filter_test.rb
@@ -54,8 +54,15 @@ class ProfanityFilterTest < Minitest::Test
   end
 
   def test_profanity_with_ignore_list
-    assert ProfanityFilter.new.profane?('Scunthorpe')
-    refute ProfanityFilter.new(ignore_list: ['scunthorpe']).profane?('Scunthorpe United')
+    basic_filter = ProfanityFilter.new
+    assert basic_filter.profane?('Scunthorpe United')
+    assert basic_filter.profane?('Shitake mushrooms')
+
+    filter_with_exceptions = ProfanityFilter.new(ignore_list: ['scunthorpe', /shii?take/i])
+    refute filter_with_exceptions.profane?('Scunthorpe United')
+    refute filter_with_exceptions.profane?('Shitake mushrooms')
+    assert filter_with_exceptions.profane?('what a cunt!')
+    assert filter_with_exceptions.profane?('Shithead!')
   end
 
   def test_config_strategies_with_nonexistent_name_throws_exception

--- a/test/profanity_filter_test.rb
+++ b/test/profanity_filter_test.rb
@@ -47,16 +47,15 @@ class ProfanityFilterTest < Minitest::Test
     end
   end
 
-  def test_profanity_with_unsupported_whitelist_format
+  def test_profanity_with_unsupported_ignore_list_format
     assert_raises do
-      ProfanityFilter.new(whitelist: 'unsupported')
+      ProfanityFilter.new(ignore_list: 'unsupported')
     end
   end
 
-  def test_profanity_with_whitelist
-    profane_word = 'shit'
-    assert ProfanityFilter.new.profane?(profane_word)
-    refute ProfanityFilter.new(whitelist: [profane_word]).profane?(profane_word)
+  def test_profanity_with_ignore_list
+    assert ProfanityFilter.new.profane?('Scunthorpe')
+    refute ProfanityFilter.new(ignore_list: ['scunthorpe']).profane?('Scunthorpe United')
   end
 
   def test_config_strategies_with_nonexistent_name_throws_exception


### PR DESCRIPTION
...and allow it to be used to solve the [Scunthorpe problem](https://en.wikipedia.org/wiki/Scunthorpe_problem).

There are a couple of things going on here: firstly I had a couple of cases of the scunthorpe problem which weren't addressed using the original whitelist solution. Secondly, I [and others](https://www.ncsc.gov.uk/blog-post/terminology-its-not-black-and-white) have been trying to avoid problematic language in my code, and "whitelist" falls into that category. I appreciate that this is a breaking change, and if you like I can add another commit to make it backwards-compatible.